### PR TITLE
챕터 3 엔딩씬과 연결, 챕터 2, 3에 챕터 이동 효과음 추가

### DIFF
--- a/Game/Assets/Scenes/Chapter2.unity
+++ b/Game/Assets/Scenes/Chapter2.unity
@@ -471,13 +471,12 @@ Transform:
   - {fileID: 1948253359}
   - {fileID: 226154088}
   - {fileID: 1352501803}
-  - {fileID: 867880870}
   - {fileID: 1561818853}
   - {fileID: 1831673208}
   - {fileID: 699216704}
   - {fileID: 729687386}
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &45491077
 GameObject:
@@ -3285,7 +3284,7 @@ Transform:
   - {fileID: 1836491127}
   - {fileID: 1620552396}
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &166134904
 GameObject:
@@ -4181,6 +4180,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   respawnManager: {fileID: 1809456938}
+  audioSource: {fileID: 631155832}
+  clip: {fileID: 8300000, guid: ad27e828e00934ac6ac9254f6166fb5c, type: 3}
 --- !u!114 &242017382
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4277,13 +4278,13 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 242017380}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 85.94, y: -0.02, z: 1.0410156}
+  m_LocalPosition: {x: 16.79499, y: 4.8481555, z: 90.50675}
   m_LocalScale: {x: 0.4, y: 0.4, z: 1}
   m_Children:
   - {fileID: 1312682322}
   - {fileID: 1251895841}
-  m_Father: {fileID: 621568855}
-  m_RootOrder: 7
+  m_Father: {fileID: 1030405208}
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &243280093
 GameObject:
@@ -6082,7 +6083,7 @@ Transform:
   m_Children:
   - {fileID: 275249421}
   m_Father: {fileID: 0}
-  m_RootOrder: 1
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &268576578
 GameObject:
@@ -6294,7 +6295,7 @@ Transform:
   - {fileID: 1838536861}
   - {fileID: 1025036450}
   m_Father: {fileID: 1766660646}
-  m_RootOrder: 14
+  m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &281139402
 MonoBehaviour:
@@ -9467,6 +9468,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   respawnManager: {fileID: 1809456938}
+  audioSource: {fileID: 631155832}
+  clip: {fileID: 8300000, guid: ad27e828e00934ac6ac9254f6166fb5c, type: 3}
 --- !u!114 &425113501
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -9563,13 +9566,13 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 425113499}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 86.45, y: 13.28, z: 1.0410156}
+  m_LocalPosition: {x: 17.304985, y: 18.148155, z: 90.50675}
   m_LocalScale: {x: 0.4, y: 0.4, z: 1}
   m_Children:
   - {fileID: 897206109}
   - {fileID: 2023022700}
-  m_Father: {fileID: 1766660646}
-  m_RootOrder: 10
+  m_Father: {fileID: 1030405208}
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &444976395
 GameObject:
@@ -10628,7 +10631,7 @@ Transform:
   m_Children:
   - {fileID: 1574671834}
   m_Father: {fileID: 0}
-  m_RootOrder: 2
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &518280448
 GameObject:
@@ -11096,13 +11099,12 @@ Transform:
   - {fileID: 500964361}
   - {fileID: 103785639}
   - {fileID: 1097112207}
-  - {fileID: 242017385}
   - {fileID: 2140104781}
   - {fileID: 1019796007}
   - {fileID: 1998146716}
   - {fileID: 1246157578}
   m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &622896315
 GameObject:
@@ -11436,7 +11438,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 13
+  m_RootOrder: 15
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &635480229
 GameObject:
@@ -12966,7 +12968,7 @@ Transform:
   - {fileID: 1236164083}
   - {fileID: 691451610}
   m_Father: {fileID: 28093374}
-  m_RootOrder: 10
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &699216705
 MonoBehaviour:
@@ -13323,7 +13325,7 @@ Transform:
   - {fileID: 1779926915}
   - {fileID: 975741440}
   m_Father: {fileID: 1766660646}
-  m_RootOrder: 12
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &718784664
 MonoBehaviour:
@@ -13557,7 +13559,7 @@ Transform:
   - {fileID: 18576137}
   - {fileID: 1064910836}
   m_Father: {fileID: 28093374}
-  m_RootOrder: 11
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &729687387
 MonoBehaviour:
@@ -13778,7 +13780,7 @@ Transform:
   - {fileID: 695149217}
   - {fileID: 415683162}
   m_Father: {fileID: 0}
-  m_RootOrder: 9
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &752671373
 GameObject:
@@ -14803,6 +14805,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   respawnManager: {fileID: 1809456938}
+  audioSource: {fileID: 631155832}
+  clip: {fileID: 8300000, guid: ad27e828e00934ac6ac9254f6166fb5c, type: 3}
 --- !u!114 &867880867
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -14899,13 +14903,13 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 867880865}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 38.38, y: 4.46, z: 0}
+  m_LocalPosition: {x: -48.76501, y: 9.3281555, z: 89.46574}
   m_LocalScale: {x: 0.4, y: 0.4, z: 1}
   m_Children:
   - {fileID: 870265149}
   - {fileID: 71015864}
-  m_Father: {fileID: 28093374}
-  m_RootOrder: 7
+  m_Father: {fileID: 1030405208}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &868544555
 GameObject:
@@ -15383,7 +15387,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 10
+  m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &946553370
 GameObject:
@@ -15779,7 +15783,7 @@ Transform:
   - {fileID: 1505508029}
   - {fileID: 1305801952}
   m_Father: {fileID: 621568855}
-  m_RootOrder: 9
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1019796008
 MonoBehaviour:
@@ -16074,6 +16078,40 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+--- !u!1 &1030405207
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1030405208}
+  m_Layer: 0
+  m_Name: Memory
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1030405208
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1030405207}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 87.14501, y: -4.8681555, z: -89.46574}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1856414804}
+  - {fileID: 867880870}
+  - {fileID: 242017385}
+  - {fileID: 425113504}
+  m_Father: {fileID: 0}
+  m_RootOrder: 10
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1037072101
 GameObject:
   m_ObjectHideFlags: 0
@@ -17268,7 +17306,7 @@ Transform:
   - {fileID: 62168222}
   - {fileID: 1919409188}
   m_Father: {fileID: 1180245546}
-  m_RootOrder: 7
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1180085939
 MonoBehaviour:
@@ -17389,13 +17427,12 @@ Transform:
   - {fileID: 464485085}
   - {fileID: 1096068001}
   - {fileID: 1608035109}
-  - {fileID: 1856414804}
   - {fileID: 1477033806}
   - {fileID: 2116544563}
   - {fileID: 1180085938}
   - {fileID: 1568626876}
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1188317447
 GameObject:
@@ -18029,7 +18066,7 @@ Transform:
   - {fileID: 770427989}
   - {fileID: 243280094}
   m_Father: {fileID: 1766660646}
-  m_RootOrder: 11
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1241818867
 MonoBehaviour:
@@ -18152,7 +18189,7 @@ Transform:
   - {fileID: 1412489575}
   - {fileID: 752671374}
   m_Father: {fileID: 621568855}
-  m_RootOrder: 11
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1246157579
 MonoBehaviour:
@@ -18713,6 +18750,7 @@ GameObject:
   - component: {fileID: 1297866918}
   - component: {fileID: 1297866917}
   - component: {fileID: 1297866916}
+  - component: {fileID: 1297866919}
   m_Layer: 0
   m_Name: item14
   m_TagString: Untagged
@@ -18824,6 +18862,21 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &1297866919
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1297866914}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0b351ccc2ea88574b8067a95536f62e9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  respawnManager: {fileID: 1809456938}
+  audioSource: {fileID: 631155832}
+  clip: {fileID: 8300000, guid: ad27e828e00934ac6ac9254f6166fb5c, type: 3}
 --- !u!1 &1305801951
 GameObject:
   m_ObjectHideFlags: 0
@@ -26388,7 +26441,7 @@ Transform:
   - {fileID: 1937960928}
   - {fileID: 1439610058}
   m_Father: {fileID: 1766660646}
-  m_RootOrder: 13
+  m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1382448326
 MonoBehaviour:
@@ -27836,7 +27889,7 @@ Transform:
   - {fileID: 1388337283}
   - {fileID: 1291564993}
   m_Father: {fileID: 1180245546}
-  m_RootOrder: 5
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1477033807
 MonoBehaviour:
@@ -28749,7 +28802,7 @@ Transform:
   - {fileID: 1039575439}
   - {fileID: 1385207523}
   m_Father: {fileID: 28093374}
-  m_RootOrder: 8
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1561818854
 MonoBehaviour:
@@ -28873,7 +28926,7 @@ Transform:
   - {fileID: 1406000491}
   - {fileID: 1148344171}
   m_Father: {fileID: 1180245546}
-  m_RootOrder: 8
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1568626877
 MonoBehaviour:
@@ -28976,6 +29029,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   respawnManager: {fileID: 1809456938}
+  audioSource: {fileID: 0}
+  clip: {fileID: 0}
 --- !u!1 &1569228523
 GameObject:
   m_ObjectHideFlags: 0
@@ -29388,7 +29443,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 12
+  m_RootOrder: 14
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1591633623
 GameObject:
@@ -30059,6 +30114,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   respawnManager: {fileID: 1809456938}
+  audioSource: {fileID: 631155832}
+  clip: {fileID: 8300000, guid: ad27e828e00934ac6ac9254f6166fb5c, type: 3}
 --- !u!1 &1628277801
 GameObject:
   m_ObjectHideFlags: 0
@@ -30184,7 +30241,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 15
+  m_RootOrder: 17
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1640591913
 GameObject:
@@ -31391,13 +31448,12 @@ Transform:
   - {fileID: 444976396}
   - {fileID: 1700212663}
   - {fileID: 1246196968}
-  - {fileID: 425113504}
   - {fileID: 1241818866}
   - {fileID: 718784663}
   - {fileID: 1382448325}
   - {fileID: 281139401}
   m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1779926914
 GameObject:
@@ -31884,7 +31940,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 16
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1811320034
 GameObject:
@@ -32368,7 +32424,7 @@ Transform:
   - {fileID: 698383159}
   - {fileID: 1048330222}
   m_Father: {fileID: 28093374}
-  m_RootOrder: 9
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1831673209
 MonoBehaviour:
@@ -32837,6 +32893,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   respawnManager: {fileID: 1809456938}
+  audioSource: {fileID: 631155832}
+  clip: {fileID: 8300000, guid: ad27e828e00934ac6ac9254f6166fb5c, type: 3}
 --- !u!114 &1856414801
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -32933,13 +32991,13 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1856414799}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 37.05, y: -4.67, z: 1.0410156}
+  m_LocalPosition: {x: -50.095013, y: 0.1981554, z: 90.50675}
   m_LocalScale: {x: 0.2, y: 0.2, z: 1}
   m_Children:
   - {fileID: 1863713445}
   - {fileID: 497882469}
-  m_Father: {fileID: 1180245546}
-  m_RootOrder: 4
+  m_Father: {fileID: 1030405208}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1863713444
 GameObject:
@@ -36618,7 +36676,7 @@ Transform:
   - {fileID: 311985343}
   - {fileID: 1248532334}
   m_Father: {fileID: 621568855}
-  m_RootOrder: 10
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1998146717
 MonoBehaviour:
@@ -37221,7 +37279,7 @@ Transform:
   - {fileID: 1381063577}
   - {fileID: 635480230}
   m_Father: {fileID: 1180245546}
-  m_RootOrder: 6
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &2116544564
 MonoBehaviour:
@@ -37436,7 +37494,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 14
+  m_RootOrder: 16
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2123858951
 GameObject:
@@ -37581,7 +37639,7 @@ Transform:
   - {fileID: 1450971826}
   - {fileID: 1591633624}
   m_Father: {fileID: 621568855}
-  m_RootOrder: 8
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &2140104782
 MonoBehaviour:
@@ -37763,7 +37821,7 @@ RectTransform:
   m_Children:
   - {fileID: 15883992}
   m_Father: {fileID: 0}
-  m_RootOrder: 11
+  m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -37844,7 +37902,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 8
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &2145780997
 MonoBehaviour:

--- a/Game/Assets/Scenes/Chapter3.unity
+++ b/Game/Assets/Scenes/Chapter3.unity
@@ -396,6 +396,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   respawnManager: {fileID: 33531657}
+  audioSource: {fileID: 0}
+  clip: {fileID: 0}
 --- !u!61 &42367646
 BoxCollider2D:
   m_ObjectHideFlags: 0
@@ -941,6 +943,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   respawnManager: {fileID: 33531657}
+  audioSource: {fileID: 144288019}
+  clip: {fileID: 8300000, guid: ad27e828e00934ac6ac9254f6166fb5c, type: 3}
 --- !u!61 &84034127
 BoxCollider2D:
   m_ObjectHideFlags: 0
@@ -15045,6 +15049,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   respawnManager: {fileID: 33531657}
+  audioSource: {fileID: 144288019}
+  clip: {fileID: 8300000, guid: ad27e828e00934ac6ac9254f6166fb5c, type: 3}
 --- !u!61 &771620085
 BoxCollider2D:
   m_ObjectHideFlags: 0
@@ -16836,6 +16842,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   respawnManager: {fileID: 33531657}
+  audioSource: {fileID: 144288019}
+  clip: {fileID: 8300000, guid: ad27e828e00934ac6ac9254f6166fb5c, type: 3}
 --- !u!61 &849815004
 BoxCollider2D:
   m_ObjectHideFlags: 0
@@ -19168,6 +19176,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   respawnManager: {fileID: 33531657}
+  audioSource: {fileID: 144288019}
+  clip: {fileID: 8300000, guid: ad27e828e00934ac6ac9254f6166fb5c, type: 3}
 --- !u!61 &1087915784
 BoxCollider2D:
   m_ObjectHideFlags: 0
@@ -19543,6 +19553,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   respawnManager: {fileID: 33531657}
+  audioSource: {fileID: 0}
+  clip: {fileID: 0}
 --- !u!61 &1103721630
 BoxCollider2D:
   m_ObjectHideFlags: 0
@@ -27280,6 +27292,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   respawnManager: {fileID: 33531657}
+  audioSource: {fileID: 144288019}
+  clip: {fileID: 8300000, guid: ad27e828e00934ac6ac9254f6166fb5c, type: 3}
 --- !u!212 &1732029168
 SpriteRenderer:
   m_ObjectHideFlags: 0

--- a/Game/Assets/Scripts/Chapter1/SelectMemory1.cs
+++ b/Game/Assets/Scripts/Chapter1/SelectMemory1.cs
@@ -88,6 +88,9 @@ public class SelectMemory1 : MonoBehaviour
 
     IEnumerator Wait()
     {
+        Debug.Log(Management.staff);
+        Debug.Log(Management.cat);
+
         yield return new WaitForSeconds(3f);
         audioSource.clip = clip;
         audioSource.Play();

--- a/Game/Assets/Scripts/Chapter2/SelectMemory2.cs
+++ b/Game/Assets/Scripts/Chapter2/SelectMemory2.cs
@@ -10,6 +10,12 @@ public class SelectMemory2 : MonoBehaviour
     [SerializeField]
     private RespawnManager2 respawnManager;
 
+    [SerializeField]
+    private AudioSource audioSource;
+
+    [SerializeField]
+    private AudioClip clip;
+
     // Start is called before the first frame update
     void Start()
     {
@@ -39,9 +45,9 @@ public class SelectMemory2 : MonoBehaviour
             respawnManager.SetRespawnMemory("memory1-2");
             Management.C = 2;
         }
-        else if (gameObject.name == "item13")
+        else if (gameObject.name == "item14")
         {
-            respawnManager.SetRespawnMemory("item13");
+            respawnManager.SetRespawnMemory("item14");
         }
         else if (gameObject.name == "memory2-1")
         {
@@ -72,9 +78,13 @@ public class SelectMemory2 : MonoBehaviour
 
     IEnumerator Wait()
     {
-        Debug.Log("전환");
+        Debug.Log(Management.staff);
+        Debug.Log(Management.cat);
+
         yield return new WaitForSeconds(3f);
+        audioSource.clip = clip;
+        audioSource.Play();
+        DontDestroyOnLoad(audioSource);
         SceneManager.LoadScene("Chapter3");
-        
     }
 }

--- a/Game/Assets/Scripts/Chapter3/SelectMemory3.cs
+++ b/Game/Assets/Scripts/Chapter3/SelectMemory3.cs
@@ -10,6 +10,12 @@ public class SelectMemory3 : MonoBehaviour
     [SerializeField]
     private RespawnManager3 respawnManager;
 
+    [SerializeField]
+    private AudioSource audioSource;
+
+    [SerializeField]
+    private AudioClip clip;
+
     // Start is called before the first frame update
     void Start()
     {
@@ -76,8 +82,20 @@ public class SelectMemory3 : MonoBehaviour
 
     IEnumerator Wait()
     {
-        Debug.Log("전환");
+        Debug.Log(Management.staff);
+        Debug.Log(Management.cat);
+
         yield return new WaitForSeconds(3f);
-        SceneManager.LoadScene("Chapter1");
+        audioSource.clip = clip;
+        audioSource.Play();
+        DontDestroyOnLoad(audioSource);
+        if (Management.cat == 3)
+        {
+            SceneManager.LoadScene("EndingScene");
+        }
+        else
+        {
+            SceneManager.LoadScene("Chapter1");
+        }
     }
 }


### PR DESCRIPTION
챕터3이 엔딩씬과 연결되도록 SelectMemory3 수정
- 챕터 2, 3에서 고양이 대사 출력되지 않는 문제 있음
- 챕터 전환 시 CatControlandSound에서 nullReference 오류 발생하는 문제 있음
- 챕터 3->1의 경우 챕터 전환 효과음이 중간에 끊기는 문제 있음